### PR TITLE
Use JAX-RS feature instead of servlet filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,19 +49,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- Shiro + cache -->
-    <dependency>
-      <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-web</artifactId>
-      <version>${dependency.shiro.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-servlet-plugin</artifactId>
-      <version>${dependency.shiro.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-jaxrs</artifactId>

--- a/src/main/java/io/github/bmhm/shiro/shiro678/RestApplication.java
+++ b/src/main/java/io/github/bmhm/shiro/shiro678/RestApplication.java
@@ -1,8 +1,20 @@
 package io.github.bmhm.shiro.shiro678;
 
+import org.apache.shiro.web.jaxrs.ShiroFeature;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
 
 @ApplicationPath("/")
 public class RestApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(ShiroFeature.class);
+        classes.add(JaxRsEndpoint.class);
+        return classes;
+    }
 }


### PR DESCRIPTION
I'll add this to the related JIRA too, but here is what I found (I'm making a few assumptions here too)

Containers use `ISO-8859-1` per the servlet spec
It looks like JAX-RS implementations use UTF-8 (assumption)

When using a servlet filter, the character set is getting picked up by the container (as the servlet filter is processed before the JAX-RS implementation)

Switching to using the ShiroFeature, fixes the problem as that _should_ be processed from the contains of the JAX-RS implementation.

If you want to continue to use the ServletFitler, you can, but you would need to change the container's default encoding.

Tomcat has a great writeup on the topic and instructions on how to use UTF-8 instead:
https://cwiki.apache.org/confluence/display/TOMCAT/Character+Encoding

**NOTE:** adding `; charset=utf-8` to request content-type also _fixes_ this, but would be less intuitive for anyone using UTF-8 and just want it to _work_


Again, I'm making a few assumptions here, so let me know if you think I'm off